### PR TITLE
fix: add server heartbeat ping

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -39,7 +39,7 @@ export async function experimental_serverChannel(
               console.log("args: ", json.args[0]);
             }
 
-            if (json.args.length > 0) {
+            if (json.args && Array.isArray(json.args) && json.args.length > 0) {
               channel.emit?.(json.type, json.args[0]);
             } else {
               channel.emit?.(json.type);
@@ -49,6 +49,12 @@ export async function experimental_serverChannel(
           }
         });
       });
+
+      setInterval(function ping() {
+        wss.clients.forEach(function each(ws) {
+          ws.send(JSON.stringify({ type: "ping", args: [] }));
+        });
+      }, 10000);
 
       [
         ...Object.values(EVENTS),


### PR DESCRIPTION
- Added a 10s interval sending a heartbeat ping to all clients.

Storybook client expects pings in `{ type: "ping", args: [] }` format, not standard WebSocket pings otherwise it disconnects after 20s. [Source](https://github.com/storybookjs/storybook/blob/8932f3ba2b2accb9064043b025c536a3583a85b3/code/core/src/channels/websocket/index.ts#L55).
Also in return client sends back `{ type: 'pong' }`. The added `json.args` check is because of this

versions used:
```
"storybook": "^8.6.14",
"@storybook/react": "^8.6.14",
"@storybook/react-native": "^8.6.4",
```
